### PR TITLE
remove central router logic in the controller

### DIFF
--- a/plugins/DTPController.cpp
+++ b/plugins/DTPController.cpp
@@ -116,12 +116,12 @@ void DTPController::do_configure(const data_t& args) {
   // CRIF
   //
   // set CRIF to drop empty
-  TLOG_DEBUG(TLVL_INFO) << get_name() << ": setting CRIF to drop empy packets";
-  m_pod->get_crif_node().set_drop_empty();
+  // TLOG_DEBUG(TLVL_INFO) << get_name() << ": setting CRIF to drop empy packets";
+  // m_pod->get_crif_node().set_drop_empty();
 
   // enable CRIF
-  TLOG_DEBUG(TLVL_INFO) << get_name() << ": enabling CRIF output";
-  m_pod->get_crif_node().enable();
+  // TLOG_DEBUG(TLVL_INFO) << get_name() << ": enabling CRIF output";
+  // m_pod->get_crif_node().enable();
 
 
   //
@@ -291,12 +291,12 @@ void DTPController::do_reset(const data_t& /* args */) {
 //-----------------------------------------------------------------------------
 void DTPController::get_info(opmonlib::InfoCollector& ci, int /*level*/) {
 
-  auto pkt_ctr = m_pod->get_crif_node().getNode("csr.s3_crif-out.pkt_ctr").read();
-  m_pod->get_node().getClient().dispatch();
+  // auto pkt_ctr = m_pod->get_crif_node().getNode("csr.s3_crif-out.pkt_ctr").read();
+  // m_pod->get_node().getClient().dispatch();
 
-  dtpcontrollerinfo::Info module_info;
-  module_info.dummy = pkt_ctr.value();
-  ci.add(module_info);
+  // dtpcontrollerinfo::Info module_info;
+  // module_info.dummy = pkt_ctr.value();
+  // ci.add(module_info);
 
 
 }


### PR DESCRIPTION
firmware used at latest integration tests no longer have a top level central router interface but on per stream processor, thus adjustments to the address tables and dtpcontrols is needed. For immediate running these comments can be disabled.